### PR TITLE
chore(deps): update @voltagent packages to latest versions

### DIFF
--- a/examples/with-zhipu-ai/package.json
+++ b/examples/with-zhipu-ai/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.10",
-    "@voltagent/cli": "^0.1.2",
-    "@voltagent/core": "^0.1.5",
-    "@voltagent/vercel-ai": "^0.1.2",
+    "@voltagent/cli": "^0.1.5",
+    "@voltagent/core": "^0.1.15",
+    "@voltagent/vercel-ai": "^0.1.7",
     "@voltagent/zhipu-ai": "workspace:^",
     "zod": "^3.24.2"
   },


### PR DESCRIPTION
Bump @voltagent/cli from 0.1.2 to 0.1.5, core from 0.1.5 to 0.1.15, and vercel-ai from 0.1.2 to 0.1.7 in with-zhipu-ai example to ensure compatibility with recent fixes and improvements.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
